### PR TITLE
fix postage stamp bounds in extractPSF

### DIFF
--- a/example_scripts/simple_shear.py
+++ b/example_scripts/simple_shear.py
@@ -249,7 +249,7 @@ def extractPSF(starfield_im):
     ps_size = shape[0] / 3
 
     # Cut out the lower-left postage stamp.
-    psf_im = starfield_im[galsim.BoundsI(1,ps_size,1,ps_size)]
+    psf_im = starfield_im[galsim.BoundsI(0,ps_size-1,0,ps_size-1)]
     return psf_im
 
 def estimateVariance(gal_im):


### PR DESCRIPTION
The great3 image bounds are zero-indexed. It looks like the extractPSF function assumes they are one-indexed.

Minor bug, probably doesn't change things too much...

For example:

Setup:

```
import galsim
starfield_im = galsim.fits.read("/Users/daniel/data/great3/control/ground/constant/starfield_image-000-0.fits")
size = 48
```

This is okay:

```
starfield_im[galsim.BoundsI(0,size-1,0,size-1)]
<galsim._galsim.ImageViewF at 0x107f591c0>
```

This is not:

```
starfield_im[galsim.BoundsI(-1,size-2,-1,size-2)]
---------------------------------------------------------------------------
RuntimeError                              Traceback (most recent call last)
<ipython-input-12-e6dd3c2bc4d8> in <module>()
----> 1 starfield_im[galsim.BoundsI(-1,46,-1,46)]

/usr/local/lib/python2.7/site-packages/galsim/image.py in Image_getitem(self, key)
    161 
    162 def Image_getitem(self, key):
--> 163     return self.subImage(key)
    164 
    165 # Define a utility function to be used by the arithmetic functions below

RuntimeError: Image Error: Subimage bounds (-1 46 -1 46 ) are outside original image bounds (0 143 0 143 )
```
