### PR TITLE
check psf using the sigma guess defined above

### DIFF
--- a/example_scripts/simple_shear.py
+++ b/example_scripts/simple_shear.py
@@ -537,7 +537,7 @@ def EstimateAllShears(subfield, sim_dir, output_dir, output_prefix="output_catal
         # want to do it all the time.  Instead, we check once for failure of adaptive moments for
         # the PSF, and if it fails, then we adopt a smaller initial guess.
         try:
-            galsim.hsm.FindAdaptiveMom(psf_im)
+            galsim.hsm.FindAdaptiveMom(psf_im, guess_sig=guess_sig)
         except:
             guess_sig = 2.0
             try:


### PR DESCRIPTION
The initial adaptive moment test on the psf does not use the default sigma guess defined previously (guess_sig=3.0). Since this is not passed in the initial test call to FindAdaptiveMom, it's actually testing with the default guess_sig=5.0, and shape measurement will end up using guess_sig=3.0 if the test passes.
